### PR TITLE
Add aarch64 as a reference to arm64 packages

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -37,6 +37,9 @@ get_arch() {
     arm64)
       echo "arm64"
       ;;
+    aarch64)
+      echo "arm64"
+      ;;
     *)
       echo ""
   esac


### PR DESCRIPTION
Asahi Linux has the reference under `uname -m` as `aarch64` this add's that value to the `get_arch()` function